### PR TITLE
Add admin

### DIFF
--- a/app/controllers/admin/registrations_controller.rb
+++ b/app/controllers/admin/registrations_controller.rb
@@ -4,10 +4,6 @@ class Admin::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
-  def after_sign_up_path_for(resource)
-    admin_homes_top_path
-  end
-
   # GET /resource/sign_up
   # def new
   #   super

--- a/app/controllers/admin/registrations_controller.rb
+++ b/app/controllers/admin/registrations_controller.rb
@@ -4,6 +4,10 @@ class Admin::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
   # before_action :configure_account_update_params, only: [:update]
 
+  def after_sign_up_path_for(resource)
+    admin_homes_top_path
+  end
+
   # GET /resource/sign_up
   # def new
   #   super

--- a/app/controllers/admin/sessions_controller.rb
+++ b/app/controllers/admin/sessions_controller.rb
@@ -7,6 +7,10 @@ class Admin::SessionsController < Devise::SessionsController
     admin_homes_top_path
   end
 
+  def after_sign_out_path_for(resource)
+    admin_session_path
+  end
+
   # GET /resource/sign_in
   # def new
   #   super

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -6,11 +6,11 @@
     </div>
   </div>
 
-  <%= form_with url: admin_session_path, local: true do |f| %>
+  <%= form_with model: @admin, url: admin_session_path, local: true do |f| %>
     <div class="row no-gutters form-group w-75 mx-auto">
       <label for="inputEmail" class="col-2 col-form-label mx-5">メールアドレス</label>
       <div class="col-5">
-        <%= f.email_field :name, class:"form-control rounded mx-5", id: "inputEmail", placeholder:"sample@example.com" %>
+        <%= f.email_field :email, class:"form-control rounded mx-5", id: "inputEmail", placeholder:"sample@example.com" %>
       </div>
     </div>
     <div class="row no-gutters form-group w-75 mx-auto">

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -1,26 +1,28 @@
-<h2>Log in</h2>
+<div class="container">
 
-<%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
-  <div class="field">
-    <%= f.label :email %><br />
-    <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
-  </div>
-
-  <div class="field">
-    <%= f.label :password %><br />
-    <%= f.password_field :password, autocomplete: "current-password" %>
-  </div>
-
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
+  <div class="row no-gutters">
+    <div class="col-10 px-0 my-5 mx-auto">
+      <h5 class="float-left font-weight-bold bg-light px-3">管理者ログイン</h5>
     </div>
+  </div>
+
+  <%= form_with url: admin_session_path, local: true do |f| %>
+    <div class="row no-gutters form-group w-75 mx-auto">
+      <label for="inputEmail" class="col-2 col-form-label mx-5">メールアドレス</label>
+      <div class="col-5">
+        <%= f.email_field :name, class:"form-control rounded mx-5", id: "inputEmail", placeholder:"sample@example.com" %>
+      </div>
+    </div>
+    <div class="row no-gutters form-group w-75 mx-auto">
+      <label for="inputPassword" class="col-2 col-form-label mx-5">パスワード</label>
+      <div class="col-5">
+        <%= f.password_field :password, autocomplete: "current-password", class:"form-control rounded mx-5", id: "inputPassword" %>
+      </div>
+    </div>
+    <%= f.submit "ログイン", class:"btn btn-block btn-primary w-25 mx-auto my-5" %>
   <% end %>
 
-  <div class="actions">
-    <%= f.submit "Log in" %>
-  </div>
-<% end %>
+</div>
+
 
 <%= render "admin/shared/links" %>

--- a/app/views/admin/shared/_links.html.erb
+++ b/app/views/admin/shared/_links.html.erb
@@ -1,7 +1,7 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name) %><br />
+  <%= link_to "Admin Log in", new_session_path(resource_name) %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "Admin Sign up", new_registration_path(resource_name) %><br />
 <% end %>


### PR DESCRIPTION
更新したとこ
・Viewの作成（管理者側　devise/sessions/new）
・サインアウトした際の遷移先を設定
・サインアップ、サインインのview下部にあるリンクの文字列に「Admin」を追加
　※後々削除する記述だが、分かりやすいように

伝えたいこと
サインイン⇒「管理者トップページ」に遷移
サインアウト⇒「管理者ログイン画面」に遷移
※サインアップ⇒「Yay! You’re on Rails!」に遷移
　後々削除する為、routesファイルに記載していない

「管理者トップページ（admin_homes_top）」の「admin Log out」リンクは残してます
※ヘッダーが完成したら消します