### PR TITLE
顧客側の商品一覧・商品詳細

### DIFF
--- a/app/controllers/public/addresses_controller.rb
+++ b/app/controllers/public/addresses_controller.rb
@@ -34,8 +34,8 @@ class Public::AddressesController < ApplicationController
   end
 
   def destroy
-    @address = Address.find(params[:id])
-    @address.destroy
+    address = Address.find(params[:id])
+    address.destroy
     redirect_to addresses_path
   end
 

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,11 +1,13 @@
 class Public::ItemsController < ApplicationController
   def index
-    @items = Item.all
-    @item = Item.page(params[:page]).per(8)
+    @item_all = Item.all
+    @items = Item.page(params[:page]).per(8)
     @genres = Genre.all
   end
 
   def show
+    @item_all = Item.all
+    @items = Item.page(params[:page]).per(8)
     @item = Item.find(params[:id])
     @cart_item = CartItem.new
     @genres = Genre.all

--- a/app/controllers/public/items_controller.rb
+++ b/app/controllers/public/items_controller.rb
@@ -1,12 +1,13 @@
 class Public::ItemsController < ApplicationController
   def index
     @items = Item.all
-    @item = Item.page(params[:page])
+    @item = Item.page(params[:page]).per(8)
     @genres = Genre.all
   end
 
   def show
     @item = Item.find(params[:id])
     @cart_item = CartItem.new
+    @genres = Genre.all
   end
 end

--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -23,14 +23,14 @@
                 <%= image_tag cart_item.item.get_image(100, 70) %>
                 <%= cart_item.item.name %>
               </td>
-              <td class='align-middle'><%= cart_item.item.with_tax_price%></td>
+              <td class='align-middle'><%= number_with_delimiter(cart_item.item.with_tax_price) %></td>
               <td class='align-middle'>
                 <%= form_with model:cart_item, url:cart_item_path(cart_item.id) , local:true do |f| %>
                   <%= f.select :amount, *[1..10] %>
                   <%= f.submit "変更" , class: "btn btn-success" %>
                 <% end %>
               </td>
-              <td class='align-middle'><%= cart_item.subtotal%></td>
+              <td class='align-middle'><%= number_with_delimiter(cart_item.subtotal) %></td>
               <td class="text-center align-middle"><%= link_to "削除する", cart_item_path(cart_item.id), method: :delete, "data-confirm" => "商品を削除しますか？" , class: "btn btn-danger"%></td>
             </tr>
             <% @total = @total + cart_item.subtotal %>
@@ -45,7 +45,7 @@
         <table class="table table-bordered text-left">
           <tr>
             <th class="col-2 bg-light">合計金額</th>
-            <td class="col-2"><%= @total %></td>
+            <td class="col-2"><%= number_with_delimiter(@total) %></td>
           </tr>
         </table>
       </div>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -16,9 +16,11 @@
         <div class="row">
           <% @items.first(4).each do |item| %>
           <div class="col-lg-3">
-            <%= image_tag item.get_image(50,50); %>
-            <div class="m-2"><%= item.name %></div>
-            <div class="m-2">￥<%= item.price %></div>
+            <%= link_to item_path(item) do %>
+              <%= image_tag item.get_image(50,50); %>
+              <div class="m-2 text-dark"><%= item.name %></div>
+              <div class="m-2 text-dark">￥<%= number_with_delimiter(item.price) %></div>
+            <% end %>
           </div>
           <% end %>
         </div>
@@ -28,7 +30,7 @@
         <!--< %= link_to "すべての商品を見る >", items_path, class: "text-right"%>-->
 
         <!--View作成テスト用-->
-        <a href="/">全ての商品を見る ></a>
+        <a href="<%= items_path(@items) %>">全ての商品を見る ></a>
       </div>
     </div>
   </div>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -7,10 +7,10 @@
     <!--商品一覧-->
     <div class="col-md-8 offset-md-1 pt-5">
       <h3 class="font-weight-bolder d-inline-block">商品一覧</h3>
-      <h5 class="d-inline-block">(全<%= @items.count %>件)</h5>
+      <h5 class="d-inline-block">(全<%= @item_all.count %>件)</h5>
       <!--商品をeachで表示-->
       <div class="d-flex flex-wrap">
-        <% @item.each do |item| %>
+        <% @items.each do |item| %>
           <div class="mt-4 col-3">
             <%= link_to item_path(item) do %>
               <div class="d-inline-block"><%= image_tag item.get_image(175,175), class: 'd-inline-block' %></div>
@@ -23,7 +23,7 @@
       <!--ページネーション-->
       <div class="row mt-5 text-center mx-auto">
         <span class="mx-auto">
-          <%= paginate @item %>
+          <%= paginate @items %>
         </span>
       </div>
 

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -11,15 +11,23 @@
       <!--商品をeachで表示-->
       <div class="d-flex flex-wrap">
         <% @item.each do |item| %>
-          <div class="mt-4 col-4">
-              <span class="d-inline-block"><%= image_tag item.get_image(100,100), class: 'd-inline-block' %></span>
-              <span class="d-inline-block"><%= item.name %></span>
-              <span class="d-inline-block">¥<%= item.price %></span>
+          <div class="mt-4 col-3">
+            <%= link_to item_path(item) do %>
+              <div class="d-inline-block"><%= image_tag item.get_image(175,175), class: 'd-inline-block' %></div>
+              <div class="d-inline-block my-2 text-dark"><%= item.name %></div><br>
+              <div class="d-inline-block text-dark">¥<%= item.price %></div>
+            <% end %>
           </div>
         <% end %>
       </div>
-      <%= paginate @item %>
-    </div>
+      <!--ページネーション-->
+      <div class="row mt-5 text-center mx-auto">
+        <span class="mx-auto">
+          <%= paginate @item %>
+        </span>
+      </div>
+
+    </div><!--商品一覧ここまで-->
 
   </div>
 </div>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -15,7 +15,7 @@
             <%= link_to item_path(item) do %>
               <div class="d-inline-block"><%= image_tag item.get_image(175,175), class: 'd-inline-block' %></div>
               <div class="d-inline-block my-2 text-dark"><%= item.name %></div><br>
-              <div class="d-inline-block text-dark">¥<%= item.price %></div>
+              <div class="d-inline-block text-dark">¥<%= number_with_delimiter(item.price) %></div>
             <% end %>
           </div>
         <% end %>

--- a/app/views/public/items/index.html.erb
+++ b/app/views/public/items/index.html.erb
@@ -1,20 +1,24 @@
 <div class="container">
   <div class="row">
     <!--ジャンル一覧-->
-    <div class="col-md-3">
+    <div class="col-md-3 pt-5">
       <%= render 'public/homes/genre_search', genres: @genres %>
     </div>
     <!--商品一覧-->
     <div class="col-md-8 offset-md-1 pt-5">
-      <h4>商品一覧(全<%= @items.count %>件)</h4>
+      <h3 class="font-weight-bolder d-inline-block">商品一覧</h3>
+      <h5 class="d-inline-block">(全<%= @items.count %>件)</h5>
       <!--商品をeachで表示-->
-      <div>
-        <%=%>
-          <div>
-            
+      <div class="d-flex flex-wrap">
+        <% @item.each do |item| %>
+          <div class="mt-4 col-4">
+              <span class="d-inline-block"><%= image_tag item.get_image(100,100), class: 'd-inline-block' %></span>
+              <span class="d-inline-block"><%= item.name %></span>
+              <span class="d-inline-block">¥<%= item.price %></span>
           </div>
         <% end %>
       </div>
+      <%= paginate @item %>
     </div>
 
   </div>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -49,5 +49,9 @@
       </div>
     </div>
 
+    <div class="row mx-auto">
+      <%= link_to '一覧に戻る', items_path(@items, @item_all), class: 'btn btn-secondary' %>
+    </div>
+
   </div><!--row-->
 </div><!--container-->

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -37,7 +37,7 @@
       <div class="col-5 offset-1 d-inline-block">
         <h4 class="font-weight-bold"><%= @item.name %></h4><br>
         <h6><%= @item.introduction %></h6><br>
-        <h5>¥<%= (@item.price * 1.1).round %> (税込)</h5>
+        <h5>¥<%= number_with_delimiter((@item.price * 1.1).round) %> (税込)</h5>
         <!--数量入力-->
         <div class="mt-4">
           <%= form_with model: @cart_item, url: cart_items_path, local: true do |f| %>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -1,30 +1,53 @@
-<table class="table">
-  <thead class="table-bordered text-center">
-    <%= image_tag @item.get_image(100,100) %>
-    <tr>
-      <td>商品名</td>
-      <td><%= @item.name %></td>
-    </tr>
-    <tr>
-      <td>商品説明</td>
-      <td><%= @item.introduction %></td>
-    </tr>
-    <tr>
-      <td>ジャンル</td>
-      <td><%= @item.genre.name %></td>
-    </tr>
-    <tr>
-      <td>税込価格<p>(税抜価格)</p></td>
-      <td><%= (@item.price * 1.1).round %> (<%= @item.price %>) 円</td>
-    </tr>
-    <tr>
-      <td>販売ステータス</td>
-      <td><%= @item.is_active %></td>
-    </tr>
-  </tbody>
-</table>
-<%= form_with model: @cart_item, url: cart_items_path, local: true do |f| %>
-  <%= f.hidden_field :item_id, value: @item.id %>
-  <%= f.select :amount, *[1..3] %>
-  <%= f.submit 'カートに入れる' %>
-<% end %>
+<!--<table class="table">-->
+<!--  <thead class="table-bordered text-center">-->
+<!--    %= image_tag @item.get_image(400,400) %>-->
+<!--    <tr>-->
+<!--      <td>商品名</td>-->
+<!--      <td>%= @item.name %></td>-->
+<!--    </tr>-->
+<!--    <tr>-->
+<!--      <td>商品説明</td>-->
+<!--      <td>%= @item.introduction %></td>-->
+<!--    </tr>-->
+<!--    <tr>-->
+<!--      <td>ジャンル</td>-->
+<!--      <td>%= @item.genre.name %></td>-->
+<!--    </tr>-->
+<!--    <tr>-->
+<!--      <td>税込価格<p>(税抜価格)</p></td>-->
+<!--      <td>%= (@item.price * 1.1).round %> (%= @item.price %>) 円</td>-->
+<!--    </tr>-->
+<!--    <tr>-->
+<!--      <td>販売ステータス</td>-->
+<!--      <td>%= @item.is_active %></td>-->
+<!--    </tr>-->
+<!--  </tbody>-->
+<!--</table>-->
+<div class="container">
+  <div class="row">
+    <!--ジャンル検索-->
+    <div class="col-md-3 pt-5">
+      <%= render 'public/homes/genre_search', genres: @genres %>
+    </div>
+    <!--詳細-->
+    <div class="col-md-8 offset-md-1 pt-5">
+      <div class="col-5 d-inline-block">
+        <%= image_tag @item.get_image(300,300) %>
+      </div>
+      <div class="col-5 offset-1 d-inline-block">
+        <h4 class="font-weight-bold"><%= @item.name %></h4><br>
+        <h6><%= @item.introduction %></h6><br>
+        <h5>¥<%= (@item.price * 1.1).round %> (税込)</h5>
+        <!--数量入力-->
+        <div class="mt-4">
+          <%= form_with model: @cart_item, url: cart_items_path, local: true do |f| %>
+          <%= f.hidden_field :item_id, value: @item.id %>
+          <%= f.select :amount, *[1..3] %>
+          <%= f.submit 'カートに入れる', class: 'btn btn-success ml-5' %>
+        <% end %>
+        </div>
+      </div>
+    </div>
+
+  </div><!--row-->
+</div><!--container-->


### PR DESCRIPTION
・顧客側/商品一覧、商品詳細機能とビュー
・トップ画面の「新着商品、全ての商品を見る」から商品詳細、商品一覧に飛べるようにリンクを作りました。
・トップ画面とカート一覧の金額3桁ごとにカンマで区切り入れました。
・前回作成した顧客側/配送先のコントローラにdestroyアクションでインスタンス変数を使用していた箇所を解除しました。
確認お願いいたします！