### PR TITLE
[Update]header,footer+a

### DIFF
--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -24,5 +24,6 @@
 
 </div>
 
-
+<div>
 <%= render "admin/shared/links" %>
+</div>

--- a/app/views/admin/sessions/new.html.erb
+++ b/app/views/admin/sessions/new.html.erb
@@ -24,6 +24,5 @@
 
 </div>
 
-<div>
+
 <%= render "admin/shared/links" %>
-</div>

--- a/app/views/admin/shared/_links.html.erb
+++ b/app/views/admin/shared/_links.html.erb
@@ -1,7 +1,7 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Admin Log in", new_session_path(resource_name) %><br />
+  <%= link_to "Admin Log in", new_session_path(resource_name), class:'mx-2 text-white' %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Admin Sign up", new_registration_path(resource_name) %><br />
+  <%= link_to "Admin Sign up", new_registration_path(resource_name), class:'mx-2 text-white' %><br />
 <% end %>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,8 +1,14 @@
+<style>
+footer {
+background-color:#E4AB63
+}
+</style>
+
 <footer>
-  <div class='container mt-5'>
+  <div class='container mt-5 pt-5 pb-4'>
   	<div class='row'>
-    	<div class='mx-auto'>
-    		<p>CopyRight Infratop.inc</p>
+    	<div class='mx-auto text-white'>
+    		<p>製作：Animal Lovers.</p>
     	</div>
     </div>
   </div>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -1,5 +1,21 @@
+<style>
+nav {
+background-color:#E4AB63
+}
+.btn-custommer{
+  color: #D39E5C;
+  border: none;
+  background: #FFF;
+}
+.btn-admin{
+  color: #FFF;
+  border: none;
+  background: #ab8048;
+}
+</style>
+
 <header>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <nav class="navbar navbar-expand-lg navbar-dark">
     <div class="container">
       <a class="navbar-brand mt-2" href="/"><span>ながのCAKE</span></a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarNavDropdown" aria-controls="navbarNavDropdown" aria-expanded="false" aria-label="Toggle navigation">
@@ -8,59 +24,59 @@
       <div class="collapse navbar-collapse" id="navbarNavDropdown">
         <ul class="navbar-nav ml-auto">
         <% if customer_signed_in? %>
-          <li class='mx-3 mt-2'>
+          <li class='mx-3 mt-2 text-white'>
             ようこそ、<%= current_customer.family_name %>さん！
           </li>
           <li class='mx-3'>
-            <%= link_to "マイページ", customers_mypage_path, class: 'btn btn-block border border-secondary rounded' %>
+            <%= link_to "マイページ", customers_mypage_path, class: 'btn btn-block rounded btn-custommer' %>
           </li>
           <li class='mx-3'>
-            <%= link_to "商品一覧", items_path, class: 'btn btn-block border border-secondary rounded' %>
+            <%= link_to "商品一覧", items_path, class: 'btn btn-block rounded btn-custommer' %>
           </li>
           <li class='mx-3'>
-            <%= link_to "カート", cart_items_path, class: 'btn btn-block border border-secondary rounded' %>
+            <%= link_to "カート", cart_items_path, class: 'btn btn-block rounded btn-custommer' %>
           </li>
           <li class='mx-3'>
-            <%= link_to "ログアウト", destroy_customer_session_path, class: 'btn btn-block border border-secondary rounded', method: :delete %>
+            <%= link_to "ログアウト", destroy_customer_session_path, class: 'btn btn-block rounded btn-custommer', method: :delete %>
           </li>
         <% elsif admin_signed_in? %>
-          <li class='mx-3 mt-2'>
+          <li class='mx-3 mt-2 text-white'>
             管理者ログイン中
           </li>
           <li class='mx-3'>
-            <%= link_to "商品一覧", admin_items_path, class: 'btn btn-block border border-secondary rounded' %>
+            <%= link_to "商品一覧", admin_items_path, class: 'btn btn-block rounded btn-admin' %>
           </li>
           <li class='mx-3'>
-            <%= link_to "会員一覧", admin_customers_path, class: 'btn btn-block border border-secondary rounded' %>
+            <%= link_to "会員一覧", admin_customers_path, class: 'btn btn-block rounded btn-admin' %>
           </li>
           <li class='mx-3'>
-            <%= link_to "注文履歴一覧", admin_root_path, class: 'btn btn-block border border-secondary rounded' %>
+            <%= link_to "注文履歴一覧", admin_root_path, class: 'btn btn-block rounded btn-admin' %>
           </li>
           <li class='mx-3'>
-            <%= link_to "ジャンル一覧", admin_genres_path, class: 'btn btn-block border border-secondary rounded' %>
+            <%= link_to "ジャンル一覧", admin_genres_path, class: 'btn btn-block rounded btn-admin' %>
           </li>
           <li class='mx-3'>
-            <%= link_to "ログアウト", destroy_admin_session_path, class: 'btn btn-block border border-secondary rounded', method: :delete %>
+            <%= link_to "ログアウト", destroy_admin_session_path, class: 'btn btn-block rounded btn-admin', method: :delete %>
           </li>
         <% else %>
           <li class='mx-3'>
-            <%= link_to "About", about_path, class: 'btn btn-block border border-secondary rounded' %>
+            <%= link_to "About", about_path, class: 'btn btn-block rounded btn-custommer' %>
           </li>
           <li class='mx-3'>
-            <%= link_to "商品一覧", items_path, class: 'btn btn-block border border-secondary rounded' %>
+            <%= link_to "商品一覧", items_path, class: 'btn btn-block rounded btn-custommer' %>
           </li>
           <li class='mx-3'>
-            <%= link_to "新規登録", new_customer_registration_path, class: 'btn btn-block border border-secondary rounded' %>
+            <%= link_to "新規登録", new_customer_registration_path, class: 'btn btn-block rounded btn-custommer' %>
           </li>
           <li class='mx-3'>
-            <%= link_to "ログイン", new_customer_session_path, class: 'btn btn-block border border-secondary rounded' %>
+            <%= link_to "ログイン", new_customer_session_path, class: 'btn btn-block rounded btn-custommer' %>
           </li>
         <% end %>
         </ul>
       </div>
     </div>
   </nav>
-  <nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <nav class="navbar navbar-expand-lg">
     <div class="container">
       <div class="row w-100 justify-content-end my-2">
         <div class="col-3 g-0">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -11,13 +11,22 @@
   </head>
 
   <body>
-    <%= render 'layouts/header' %>
-    <main>
-      <div style="height: 0px;" >
-        <p class="h5 text-center mt-3 text-info" id="notice"><%= notice %></p>
-      </div>
-      <%= yield %>
-    </main>
-    <%= render 'layouts/footer' %>
+    <style>
+    #notice {
+    color:#ab8048
+    }
+    </style>
+
+
+    <div>
+      <%= render 'layouts/header' %>
+      <main>
+        <div style="height: 0px;" >
+          <p class="h5 text-center mt-3" id="notice"><%= notice %></p>
+        </div>
+        <%= yield %>
+      </main>
+      <%= render 'layouts/footer' %>
+    </div>
   </body>
 </html>

--- a/app/views/public/homes/top.html.erb
+++ b/app/views/public/homes/top.html.erb
@@ -17,7 +17,7 @@
           <% @items.first(4).each do |item| %>
             <div class="col-lg-3">
               <%= link_to item_path(item) do %>
-                <%= image_tag item.get_image(50,50); %>
+                <%= image_tag item.get_image(100,100); %>
                 <div class="m-2 text-dark"><%= item.name %></div>
                 <div class="m-2 text-dark">￥<%= number_with_delimiter(item.price) %></div>
               <% end %>
@@ -25,13 +25,12 @@
           <% end %>
         </div>
       </div>
-      <div class="text-right m-2">
-        <!--商品一覧Viewへのpathが出来たらコメントアウトを外す-->
-        <!--< %= link_to "すべての商品を見る >", items_path, class: "text-right"%>-->
-
-        <!--View作成テスト用-->
-        <a href="<%= items_path(@items) %>">全ての商品を見る ></a>
+      <div class="text-right mx-2 mt-5">
+        <%= link_to "すべての商品を見る >", items_path, class: "text-dark" %>
       </div>
+    </div>
+    <div class="text-left mx-2">
+      <%= link_to "管理者　ログイン", new_admin_session_path, class:'text-white' %>
     </div>
   </div>
 </div>

--- a/app/views/public/items/show.html.erb
+++ b/app/views/public/items/show.html.erb
@@ -24,8 +24,8 @@
       </div>
     </div>
 
-    <div class="row mx-auto">
-      <%= link_to '一覧に戻る', items_path, class: 'btn btn-secondary' %>
+    <div class="row mx-auto my-5">
+      <%= link_to '一覧に戻る', items_path, class: 'btn btn-secondary mt-5' %>
     </div>
 
   </div><!--row-->


### PR DESCRIPTION
本来は実装されない、管理者のサインアップリンクを白文字にして隠しました

ヘッダーとフッターをスライドの黄色と同じ色にしました
　それに伴い、文字色と、ボタンの背景色を調整しました
フッターの文言を「製作：Animal Lovers」に差し替えました

notice（通知文）の色を、青緑からスライドの濃い黄色と同じ色にしました

顧客側のhomes/topViewの「すべての商品を見る >」がリンク（文字が青くなるやつ）だったので調整しました
白文字で「管理者ログイン」リンクを隠して配置しました

items/showViewの「一覧に戻る」ボタンの位置を少し調整しました