### PR TITLE
Add cart items

### DIFF
--- a/app/views/public/cart_items/index.html.erb
+++ b/app/views/public/cart_items/index.html.erb
@@ -53,5 +53,7 @@
   </div>
 </div>
 <div class="text-center">
-  <%= link_to "情報入力に進む" , new_order_path , class: "btn btn-success" %>
+  <% if @cart_items.count > 0 %>
+    <%= link_to "情報入力に進む" , new_order_path , class: "btn btn-success" %>
+  <% end %>
 </div>


### PR DESCRIPTION
カートが空の場合は「情報入力に進む」のリンクを表示されないようにしました。
